### PR TITLE
Fix build failure on Windows

### DIFF
--- a/src/dsp/arc_dsp.hpp
+++ b/src/dsp/arc_dsp.hpp
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "rack.hpp"
+#include <math.h>
 
 using namespace rack;
 
@@ -159,8 +160,8 @@ public:
 
         // TODO use lookup tables
         float lr = (pan + 1.0f) * 0.125f;
-        left = std::cosf(2.0f * M_PI * lr);
-        right = std::sinf(2.0f * M_PI * lr);
+        left = cosf(2.0f * M_PI * lr);
+        right = sinf(2.0f * M_PI * lr);
     }
 };
 


### PR DESCRIPTION
```
In file included from src/FM.cpp:1:
src/dsp/arc_dsp.hpp: In member function 'void arc::dsp::Panner::next(float)':
src/dsp/arc_dsp.hpp:162:21: error: 'cosf' is not a member of 'std'; did you mean 'cosh'?
  162 |         left = std::cosf(2.0f * M_PI * lr);
      |                     ^~~~
      |                     cosh
src/dsp/arc_dsp.hpp:163:22: error: 'sinf' is not a member of 'std'; did you mean 'sinh'?
  163 |         right = std::sinf(2.0f * M_PI * lr);
      |                      ^~~~
      |                      sinh
In file included from src/vu.hpp:3,
                 from src/track.hpp:5,
                 from src/GAIN.cpp:2:
src/dsp/arc_dsp.hpp: In member function 'void arc::dsp::Panner::next(float)':
src/dsp/arc_dsp.hpp:162:21: error: 'cosf' is not a member of 'std'; did you mean 'cosh'?
  162 |         left = std::cosf(2.0f * M_PI * lr);
      |                     ^~~~
      |                     cosh
src/dsp/arc_dsp.hpp:163:22: error: 'sinf' is not a member of 'std'; did you mean 'sinh'?
  163 |         right = std::sinf(2.0f * M_PI * lr);
      |                      ^~~~
      |                      sinh
make: *** [../../compile.mk:72: build/src/FM.cpp.o] Error 1
make: *** Waiting for unfinished jobs....
make: *** [../../compile.mk:72: build/src/GAIN.cpp.o] Error 1
```